### PR TITLE
Update to 1.20.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,10 @@
 archives_base_name = colorfulsubtitles
 maven_group = io.github.haykam821
-mod_version = 1.2.0
+mod_version = 1.3.0
 
 org.gradle.jvmargs = -Xmx1G
 
 # Versions
-minecraft_version = 1.19.3
-yarn_mappings = 1.19.3+build.5
-loader_version = 0.14.12
+minecraft_version=1.20.1
+yarn_mappings=1.20.1+build.10
+loader_version=0.14.21

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 archives_base_name = colorfulsubtitles
 maven_group = io.github.haykam821
-mod_version = 1.1.0
+mod_version = 1.2.0
 
 org.gradle.jvmargs = -Xmx1G
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,10 @@
 archives_base_name = colorfulsubtitles
 maven_group = io.github.haykam821
-mod_version = 1.3.0
+mod_version = 1.3.1
 
 org.gradle.jvmargs = -Xmx1G
 
 # Versions
-minecraft_version=1.20.1
-yarn_mappings=1.20.1+build.10
-loader_version=0.14.21
+minecraft_version=1.20.4
+yarn_mappings=1.20.4+build.1
+loader_version=0.15.1

--- a/src/main/java/io/github/haykam821/colorfulsubtitles/config/ColorfulSubtitlesCodecs.java
+++ b/src/main/java/io/github/haykam821/colorfulsubtitles/config/ColorfulSubtitlesCodecs.java
@@ -2,6 +2,7 @@ package io.github.haykam821.colorfulsubtitles.config;
 
 import java.util.Arrays;
 import java.util.Map;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import com.mojang.serialization.Codec;
@@ -39,6 +40,6 @@ public final class ColorfulSubtitlesCodecs {
 			}
 		}
 
-		return DataResult.error("Unknown sound category '" + name + "'");
+		return DataResult.error(() -> "Unknown sound category '" + name + "'");
 	}
 }

--- a/src/main/java/io/github/haykam821/colorfulsubtitles/mixin/SubtitlesHudMixin.java
+++ b/src/main/java/io/github/haykam821/colorfulsubtitles/mixin/SubtitlesHudMixin.java
@@ -39,7 +39,7 @@ public class SubtitlesHudMixin {
 	}
 
 	@Inject(method = "onSoundPlayed", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/SubtitlesHud$SubtitleEntry;reset(Lnet/minecraft/util/math/Vec3d;)V"), locals = LocalCapture.CAPTURE_FAILHARD)
-	private void resetColor(SoundInstance sound, WeightedSoundSet soundSet, CallbackInfo ci, Text text, Iterator<SubtitleEntry> iterator, SubtitleEntry entry) {
+	private void resetColor(SoundInstance sound, WeightedSoundSet soundSet, float range, CallbackInfo ci, Text text, Iterator<SubtitleEntry> iterator, SubtitleEntry entry) {
 		((ColorHolder) entry).setColor(sound);
 	}
 

--- a/src/main/java/io/github/haykam821/colorfulsubtitles/mixin/SubtitlesHudMixin.java
+++ b/src/main/java/io/github/haykam821/colorfulsubtitles/mixin/SubtitlesHudMixin.java
@@ -3,6 +3,7 @@ package io.github.haykam821.colorfulsubtitles.mixin;
 import java.util.Iterator;
 import java.util.List;
 
+import net.minecraft.util.math.ColorHelper;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -32,9 +33,9 @@ public class SubtitlesHudMixin {
 		return this.iterationEntry = (ColorHolder) iterator.next();
 	}
 
-	@ModifyArg(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/SubtitlesHud;drawTextWithShadow(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/font/TextRenderer;Lnet/minecraft/text/Text;III)V"), index = 5)
+	@ModifyArg(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawTextWithShadow(Lnet/minecraft/client/font/TextRenderer;Lnet/minecraft/text/Text;III)I"), index = 4)
 	private int modifyDrawColor(int color) {
-		return multiplyColors(color, this.iterationEntry.getColor());
+		return ColorHelper.Argb.mixColor(color, this.iterationEntry.getColor());
 	}
 
 	@Inject(method = "onSoundPlayed", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/SubtitlesHud$SubtitleEntry;reset(Lnet/minecraft/util/math/Vec3d;)V"), locals = LocalCapture.CAPTURE_FAILHARD)
@@ -46,19 +47,6 @@ public class SubtitlesHudMixin {
 	private boolean setColor(List<Object> entries, Object entry, SoundInstance sound, WeightedSoundSet soundSet) {
 		((ColorHolder) entry).setColor(sound);
 		return entries.add(entry);
-	}
-
-	private static int multiplyColors(int a, int b) {
-		int i = (a & 16711680) >> 16;
-		int j = (b & 16711680) >> 16;
-		int k = (a & '\uff00') >> 8;
-		int l = (b & '\uff00') >> 8;
-		int m = (a & 255) >> 0;
-		int n = (b & 255) >> 0;
-		int o = (int)((float)i * (float)j / 255.0F);
-		int p = (int)((float)k * (float)l / 255.0F);
-		int q = (int)((float)m * (float)n / 255.0F);
-		return a & -16777216 | o << 16 | p << 8 | q;
 	}
 
 }

--- a/src/main/java/io/github/haykam821/colorfulsubtitles/mixin/SubtitlesHudMixin.java
+++ b/src/main/java/io/github/haykam821/colorfulsubtitles/mixin/SubtitlesHudMixin.java
@@ -20,7 +20,6 @@ import net.minecraft.client.gui.hud.SubtitlesHud.SubtitleEntry;
 import net.minecraft.client.sound.SoundInstance;
 import net.minecraft.client.sound.WeightedSoundSet;
 import net.minecraft.text.Text;
-import net.minecraft.util.math.MathHelper;
 
 @Mixin(SubtitlesHud.class)
 @Environment(EnvType.CLIENT)
@@ -35,7 +34,7 @@ public class SubtitlesHudMixin {
 
 	@ModifyArg(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/SubtitlesHud;drawTextWithShadow(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/font/TextRenderer;Lnet/minecraft/text/Text;III)V"), index = 5)
 	private int modifyDrawColor(int color) {
-		return MathHelper.multiplyColors(color, this.iterationEntry.getColor());
+		return multiplyColors(color, this.iterationEntry.getColor());
 	}
 
 	@Inject(method = "onSoundPlayed", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/SubtitlesHud$SubtitleEntry;reset(Lnet/minecraft/util/math/Vec3d;)V"), locals = LocalCapture.CAPTURE_FAILHARD)
@@ -48,4 +47,18 @@ public class SubtitlesHudMixin {
 		((ColorHolder) entry).setColor(sound);
 		return entries.add(entry);
 	}
+
+	private static int multiplyColors(int a, int b) {
+		int i = (a & 16711680) >> 16;
+		int j = (b & 16711680) >> 16;
+		int k = (a & '\uff00') >> 8;
+		int l = (b & '\uff00') >> 8;
+		int m = (a & 255) >> 0;
+		int n = (b & 255) >> 0;
+		int o = (int)((float)i * (float)j / 255.0F);
+		int p = (int)((float)k * (float)l / 255.0F);
+		int q = (int)((float)m * (float)n / 255.0F);
+		return a & -16777216 | o << 16 | p << 8 | q;
+	}
+
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -19,6 +19,6 @@
 	"icon": "assets/colorfulsubtitles/icon.png",
 	"depends": {
 		"fabricloader": ">=0.4.0",
-		"minecraft": ">=1.20.1"
+		"minecraft": ">=1.20.4"
 	}
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -19,6 +19,6 @@
 	"icon": "assets/colorfulsubtitles/icon.png",
 	"depends": {
 		"fabricloader": ">=0.4.0",
-		"minecraft": ">=1.19.3-rc.1"
+		"minecraft": ">=1.20.1"
 	}
 }


### PR DESCRIPTION
Fixes #5 
Bump version to 1.2.0

Draft pull request as there might be a better way of doing this, I simply copied the code from `MathHelper`, as `multiplyColors` got removed in the 1.19.4 version.

Build in case anyone needs it:
https://github.com/TheMrEngMan/Colorful-Subtitles/releases/tag/1.2.0